### PR TITLE
18 two finger swipe sometimes crashes depsysio

### DIFF
--- a/src/process/dsmdbrowser.ts
+++ b/src/process/dsmdbrowser.ts
@@ -246,7 +246,7 @@ export class PRDSMDBrowser extends DSApp {
         }
         if (this._rowidx > this._curdoc.rows.length - 1)
             this._rowidx = this._curdoc.rows.length - 1;
-            
+
         if (this._rowidx != startidx)
             return true;
         else


### PR DESCRIPTION
I don't know if this is the perfect solution, but I added an error check into _changerowidx for when the document hasn't been loaded, which prevents this specific issue. I also made the website only scroll when being dragged vertically, which was originally just a way to hide the issue but made it feel a lot cleaner, so I left it in. 

We could potentially think about some way to add priority to the `EventQueue` so, for example, `ResizeAppEvents` get placed before `WheelAppEvents` or `MouseMoveEvents`?