### PR TITLE
11 can type on the website on android

### DIFF
--- a/src/process/dsmdbrowser.ts
+++ b/src/process/dsmdbrowser.ts
@@ -88,7 +88,7 @@ export class PRDSMDBrowser extends DSApp {
                     this._redraw();
 
             } else if (e instanceof TouchStartAppEvent) { // TOUCH
-                t.xterm.blur();
+                t.xterm.blur(); //Prevent keyboard from popping up on Android
                 this._touchstart = { col: e.col, row: e.row, idx: this._rowidx };
                 const rowidx = e.row + this._rowidx - 1;
                 const link = this._curdoc.getlink(e.col, rowidx);


### PR DESCRIPTION
I've added a step in dsmdbrowser
https://github.com/depsysinc/depsysweb/blob/010722955e9ed48381071304b5ead13ef7ab0750/src/process/dsmdbrowser.ts#L91
It worked on my phone when I connected to my computer's hosting, only downside is the cursor appears as hollow instead of solid.