### PR TITLE
7 tab complete for dssh

### DIFF
--- a/src/process/dssh.ts
+++ b/src/process/dssh.ts
@@ -381,7 +381,7 @@ class CommandLinePrompt {
         //Handle [tab] and autocomplete
         if (data.charAt(0) == '\t') {
             this._shell.stdout.write("\x07");
-            if (splitRespectingQuotes(this._userinput).length == 1) { //autocomplete for commands not implemented yet, so require that at least one argument has been started
+            if (splitRespectingQuotes(this._userinput).length <= 1) { //autocomplete for commands not implemented yet, so require that at least one argument has been started
                 return false;
             }
             const autocompleteOptions = this._getCwdCompletions();


### PR DESCRIPTION
This PR adds the autocomplete feature - one tab to autocomplete (if there's only one), double tab to display a list of options.

Note that it only autocompletes arguments to commands, and only with files/directories from the cwd. 