### PR TITLE
21: Ensure all Exception prototypes are explicit

### DIFF
--- a/src/filesystem/dsIDBFileSystem.ts
+++ b/src/filesystem/dsIDBFileSystem.ts
@@ -3,6 +3,7 @@ import { DSFileInfo, DSFilePerms, DSFileSystem, DSFileSystemError, DSIDirectory,
 export class DSIDBFileSystemError extends DSFileSystemError {
     constructor(message: string) {
         super(message);
+        Object.setPrototypeOf(this, DSIDBFileSystemError.prototype); 
         this.name = this.constructor.name;
     }
 }

--- a/src/lib/dsOptionParser.ts
+++ b/src/lib/dsOptionParser.ts
@@ -1,6 +1,7 @@
 export class DSOptionParserError extends Error {
     constructor(message: string) {
         super(message);
+        Object.setPrototypeOf(this, DSOptionParserError.prototype); 
         this.name = this.constructor.name;
     }
 }


### PR DESCRIPTION
I found two cases where the `Object.setPrototypeOf` command was missing, and searched through the rest, this should be good!