### PR TITLE
Remove asserting on strings

### DIFF
--- a/tests/DSFileSystem.test.ts
+++ b/tests/DSFileSystem.test.ts
@@ -319,9 +319,7 @@ test('chmod -r /gamma; ls', () => {
 
     expect(() =>
         gamma.filelist
-    ).toThrow(
-        new DSFilePermsReadError()
-    );
+    ).toThrow(DSFilePermsReadError);
 })
 
 test('chmod -x /gamma getdir /gamma/deep', () => {
@@ -331,9 +329,7 @@ test('chmod -x /gamma getdir /gamma/deep', () => {
 
     expect(() =>
         fs.root.getdir("/gamma/deep")
-    ).toThrow(
-        new DSFilePermsExecError()
-    );
+    ).toThrow(DSFilePermsExecError);
 });
 
 test('chmod -w /gamma; mkdir dirdenied from /gamma', () => {
@@ -345,9 +341,7 @@ test('chmod -w /gamma; mkdir dirdenied from /gamma', () => {
     const dirdenied = "dirdenied";
     expect(() =>
         gamma.mkdir(dirdenied)
-    ).toThrow(
-        new DSFilePermsWriteError()
-    );
+    ).toThrow(DSFilePermsWriteError);
 
 });
 
@@ -358,9 +352,7 @@ test('mkdir readonlyfs', () => {
     fs.readonly = true;
     expect(() =>
         fs.root.mkdir("readonlyfs")
-    ).toThrow(
-        new DSFileSystemReadonlyError('mkdir')
-    )
+    ).toThrow(DSFileSystemReadonlyError)
 });
 
 test('chmod readonlyfs', () => {
@@ -371,9 +363,7 @@ test('chmod readonlyfs', () => {
 
     expect(() =>
         gamma.chmod(DSFilePerms.full())
-    ).toThrow(
-        new DSFileSystemReadonlyError('chmod')
-    )
+    ).toThrow(DSFileSystemReadonlyError)
 });
 
 // filetype tests
@@ -505,9 +495,7 @@ test('contentAsText noreadperms', async () => {
 
     expect(() =>
         newfile.contentAsText()
-    ).toThrow(
-        new DSFilePermsReadError()
-    )
+    ).toThrow(DSFilePermsReadError)
 });
 
 

--- a/tests/DSKernel.test.ts
+++ b/tests/DSKernel.test.ts
@@ -45,9 +45,7 @@ test('exec /bad/path', async () => {
 
     await expect(
         DSKernel.exec("/bad/path", [], {})
-    ).rejects.toThrow(
-        DSIDirectoryInvalidPathError
-    );
+    ).rejects.toThrow(DSIDirectoryInvalidPathError);
 });
 
 test('exec /noexecperms.txt', async () => {
@@ -62,9 +60,7 @@ test('exec /noexecperms.txt', async () => {
 
     await expect(
         DSKernel.exec("/noexecperms.txt", [], {})
-    ).rejects.toThrow(
-        DSKernelExecError
-    );
+    ).rejects.toThrow(DSKernelExecError);
 });
 
 test('exec /notascript.txt', async () => {
@@ -80,9 +76,7 @@ test('exec /notascript.txt', async () => {
 
     await expect(
         DSKernel.exec("/notascript.txt", [], {})
-    ).rejects.toThrow(
-        DSKernelExecError
-    );
+    ).rejects.toThrow(DSKernelExecError);
 });
 
 test('exec /interpreternotfound.dssh', async () => {
@@ -98,9 +92,7 @@ test('exec /interpreternotfound.dssh', async () => {
 
     await expect(
         DSKernel.exec("/interpreternotfound.dssh", [], {})
-    ).rejects.toThrow(
-        DSIDirectoryInvalidPathError
-    );
+    ).rejects.toThrow(DSIDirectoryInvalidPathError);
 });
 
 test('exec /interpreternotexe.dssh', async () => {

--- a/tests/DSStream.test.ts
+++ b/tests/DSStream.test.ts
@@ -57,7 +57,7 @@ test('DSStream close then read', async () => {
 
     const promise = stream.read();
 
-    await expect(promise).rejects.toEqual(new DSStreamClosedError("End of Stream"));
+    await expect(promise).rejects.toThrow(DSStreamClosedError);
 });
 
 test('DSStream read then close', async () => {
@@ -67,7 +67,7 @@ test('DSStream read then close', async () => {
 
     stream.close();
 
-    await expect(promise).rejects.toEqual(new DSStreamClosedError("End of Stream"));
+    await expect(promise).rejects.toThrow(DSStreamClosedError);
 });
 
 test('DSStream write, close, read, read', async () => {
@@ -80,7 +80,7 @@ test('DSStream write, close, read, read', async () => {
     await expect(promise).resolves.toEqual("test string");
 
     promise = stream.read();
-    await expect(promise).rejects.toEqual(new DSStreamClosedError("End of Stream"));
+    await expect(promise).rejects.toThrow(DSStreamClosedError);
 });
 
 test('DSStream write, read, read, close', async () => {
@@ -93,7 +93,7 @@ test('DSStream write, read, read, close', async () => {
 
     promise = stream.read();
     stream.close();
-    await expect(promise).rejects.toEqual(new DSStreamClosedError("End of Stream"));
+    await expect(promise).rejects.toThrow(DSStreamClosedError);
 });
 
 test('DSStream close then write', () => {
@@ -103,9 +103,7 @@ test('DSStream close then write', () => {
 
     expect(() =>
         stream.write("test")
-    ).toThrow(
-        new DSStreamClosedError("Cannot write to closed stream")
-    );
+    ).toThrow(DSStreamClosedError);
 });
 
 /*


### PR DESCRIPTION
I've removed all the asserts on errors that involve a string that didn't seem to convey much info, plus removed some whitespace to standardize it and make it look a little nicer.

One that I didn't touch was [DSOptionParser.test.ts](https://github.com/depsysinc/depsysweb/blob/main/tests/DSOptionParser.test.ts), which has a bunch of similar errors only differentiated by message, e.g.
https://github.com/depsysinc/depsysweb/blob/7eb5e16a5aea77342135c8e4f22b686a7a132785/tests/DSOptionParser.test.ts#L36
https://github.com/depsysinc/depsysweb/blob/7eb5e16a5aea77342135c8e4f22b686a7a132785/tests/DSOptionParser.test.ts#L67
https://github.com/depsysinc/depsysweb/blob/7eb5e16a5aea77342135c8e4f22b686a7a132785/tests/DSOptionParser.test.ts#L95
Should I create some new types of `DSOptionParserError`?