### PR TITLE
72 file command returns null on dsmd files

### DIFF
--- a/src/filesystem/dsIWebFile.ts
+++ b/src/filesystem/dsIWebFile.ts
@@ -29,7 +29,7 @@ export class DSIWebFile extends DSInode {
                     //Fallback if filetype not found or not found correctly:
                     if (this._filetype == 'null' || this._filetype == 'binary/octet-stream') {
                         let spliturl = this.url.split('.');
-                        this._filetype = spliturl[spliturl.length-1]
+                        this._filetype = 'text/'+spliturl[spliturl.length-1]
                     }
                 }
             } catch (e) {


### PR DESCRIPTION
Check added!

I just took the file extension from the url of the webfile and passed it as the filetype. It doesn't have the text or image information that normal filetypes (png, txt) have, do you think that's a problem?