### PR TITLE
Change check

### DIFF
--- a/src/dsKernel.ts
+++ b/src/dsKernel.ts
@@ -170,7 +170,7 @@ export class DSKernel {
             await baudWrite(`mount: localfs\n`)
             DSKernel.mount('/local', localfs);
 
-            if (bootcount == 0) {
+            if (!fastboot) {
                 await baudWrite("nvram: enable fastboot");
                 const oldbaud = t.baud;
                 t.baud = 10;


### PR DESCRIPTION
This fixes #102 . I'm not sure if you were thinking fastboot could be an option you can change. If so, I can add a "disable_default_fastboot" or the like to nvram, but since there's no way to do that yet, I just set it to enable it for all users once you make it to the end of the initialization screen.