### PR TITLE
111 make dssh prompt prefix set from environment variable with sensible default

### DIFF
--- a/src/rootfs/base/bin/dssh.ts
+++ b/src/rootfs/base/bin/dssh.ts
@@ -28,6 +28,10 @@ export class DSShell extends DSProcess {
 
     history: string[] = [];
 
+    get promptprefix():string {
+        return this.envp['PS1'] ? this.envp['PS1'] : 'C:';
+    }
+
     protected async main(): Promise<void> {
         const optparser = new DSOptionParser(
             this.procname,
@@ -345,7 +349,7 @@ class CommandLinePrompt {
         this._cursor = 0;
 
         const stdout = this._shell.stdout;
-        this._prompt = this._shell.envp['PS1'] ? this._shell.envp['PS1'] : 'C:';
+        this._prompt = this._shell.promptprefix
         this._prompt += this._shell.cwd.path;
         this._prompt += "$ ";
         this._shell.stdout.write(this._prompt);


### PR DESCRIPTION
Let me know if this is the right way to do this! 

I moved the promptprefix to dsshell, instead of saving it in CommandLinePrompt, because otherwise the prompt won't update if the environment variable changed.

Also, sorry for the 4 commits; I made several questionable choices, then when I tried to explain them realized there was a better way :P